### PR TITLE
[Feature] Get Recipe Details

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -110,3 +110,25 @@ from the image you built from the previous command.
     - access through localhost:8080
     - [Learn more](https://docs.docker.com/config/containers/container-networking/)
 
+### How To Test Endpoints
+1. Delete the `database/data/` folder
+
+2. Run the `docker-compose up` command to build for the `dev` environment
+
+3. Run the following commands either in MySQL Workbench or by connecting to the database on the command line:
+```
+USE UMAMI_DB;
+CALL addMockUser();
+CALL addMockMissingMacroRecipe();
+CALL addMockSteps();
+CALL addMockIngredients();
+CALL addMockIngredientsInfo();
+```
+**Expected Result:** The commands above should run without any errors. If you encounter an error, you may need to remove the Docker containers and/or images manually. In this case, repeat the previous steps.
+
+4. Go to `localhost:8080/docs/`
+
+5. Expand the GET `/recipe/{recipe_id}` endpoint. Click the "Try it out" button and enter the value `1` into the `recipe_id` field.
+**Expected Result:** You should receive a response with the form shown by the example value for a 200 response. If all the previous steps worked, this should also work.
+
+6. Repeat step 5. We should get the same result as we did in step 5. This seems redundant but we are actually testing a different pathway in the code. Since we added a recipe with missing macro values, the first call in step 5 handles the case where these macro values are not present in the `recipes_table` and updates the `recipes_table` with the macro values obtained by querying the `ingredients_info_table`. The second time we call the endpoint only needs to query the `recipes_table` since we now have the macro values.

--- a/backend/app/indexer/recipes.py
+++ b/backend/app/indexer/recipes.py
@@ -56,8 +56,9 @@ def post_recipe(conn, cursor, recipe):
 
 
 def is_missing_macros(recipe_details):
-    '''Returns False if we do not have any macro information
-        from the recipe details. Otherwise returns True
+    '''
+    Returns False if we do not have any macro information
+    from the recipe details. Otherwise returns True
     '''
     return not (
         recipe_details["protein"] or
@@ -97,7 +98,7 @@ def get_ingredient_macros(conn, cursor, ingredients):
     new_cursor.close()
     return ingredient_macros
 
-def get_recipe(conn, cursor, recipe_id):
+def get_recipe_by_id(conn, cursor, recipe_id):
     '''
     Returns the available recipe details given a recipe_id
     Note: macros may still be empty if they were not added

--- a/backend/app/indexer/recipes.py
+++ b/backend/app/indexer/recipes.py
@@ -55,7 +55,54 @@ def post_recipe(conn, cursor, recipe):
         logging.error(e)
 
 
-def get_recipe(cursor, recipe_id):
+def is_missing_macros(recipe_details):
+    '''Returns False if we do not have any macro information
+        from the recipe details. Otherwise returns True
+    '''
+    return not (
+        recipe_details["protein"] or
+        recipe_details["carbs"] or
+        recipe_details["fat"] or
+        recipe_details["fiber"] or
+        recipe_details["calories"]
+    )
+
+def get_ingredient_macros(conn, cursor, ingredients):
+    '''
+    Returns the macro values for each ingredient
+    '''
+    sql = 'getIngredientInfo'
+    ingredient_macros = []
+    cursor.close()
+    new_cursor = conn.cursor()
+    for ingredient in ingredients:
+        try:
+            new_cursor.close()
+            new_cursor = conn.cursor()
+            new_cursor.callproc(sql, (ingredient["ingredient_id"], ))
+            raw_result = new_cursor.fetchall()
+            res = {
+                "ingredient_id": ingredient["ingredient_id"],
+                "protein": raw_result[0][4],
+                "carbs": raw_result[0][5],
+                "fat": raw_result[0][6],
+                "fiber": raw_result[0][7],
+                "calories": raw_result[0][8]
+            }
+            ingredient_macros.append(res)
+        except Exception as e:
+            print("MYSQL ERROR:", sql)
+            logging.error(e)
+    
+    new_cursor.close()
+    return ingredient_macros
+
+def get_recipe(conn, cursor, recipe_id):
+    '''
+    Returns the available recipe details given a recipe_id
+    Note: macros may still be empty if they were not added
+    to the recipe or corresponding ingredients
+    '''
     sql = 'getRecipe'
     try:
         cursor.callproc(sql, (recipe_id, ))
@@ -66,6 +113,8 @@ def get_recipe(cursor, recipe_id):
             "user_id": "",
             "protein": 0,
             "carbs": 0,
+            "fat": 0,
+            "fiber": 0,
             "calories": 0,
             "servings": 0,
             "vegetarian": False,
@@ -80,40 +129,79 @@ def get_recipe(cursor, recipe_id):
             res["user_id"] = raw_result[0][2]
             res["protein"] = raw_result[0][3]
             res["carbs"] = raw_result[0][4]
-            res["calories"] = raw_result[0][5]
-            res["servings"] = raw_result[0][6]
-            res["vegetarian"] = bool(raw_result[0][7])
-            res["vegan"] = bool(raw_result[0][8])
-            res["cooking_time"] = raw_result[0][9]
+            res["fat"] = raw_result[0][5]
+            res["fiber"] = raw_result[0][6]
+            res["calories"] = raw_result[0][7]
+            res["servings"] = raw_result[0][8]
+            res["vegetarian"] = bool(raw_result[0][9])
+            res["vegan"] = bool(raw_result[0][10])
+            res["cooking_time"] = raw_result[0][11]
 
             step_ids = set()
             ingredient_ids = set()
 
             for result in raw_result:
-                if result[10] not in step_ids:
+                if result[12] not in step_ids:
                     res["steps"].append(
                         {
-                            "step_id": result[10],
-                            "description": result[11],
-                            "time": result[12],
+                            "step_id": result[12],
+                            "description": result[13],
+                            "time": result[14],
                         }
                     )
-                    step_ids.add(result[10])
+                    step_ids.add(result[12])
 
-                if result[13] not in ingredient_ids:
+                if result[15] not in ingredient_ids:
                     res["ingredients"].append(
                         {
-                            "ingredient_id": result[13],
-                            "ingredient_name": result[14],
-                            "category": result[15]
+                            "ingredient_id": result[15],
+                            "ingredient_name": result[16],
+                            "category": result[17]
                         }
                     )
-                    ingredient_ids.add(result[13])
+                    ingredient_ids.add(result[15])
             
             res["steps"] = sorted(res["steps"], key=lambda step: step["step_id"])
             res["ingredients"] = sorted(res["ingredients"], key=lambda ingredient: ingredient["ingredient_id"])
-                    
-        print(res)
+
+            if is_missing_macros(res):
+                ingredient_macros = get_ingredient_macros(conn, cursor, res["ingredients"])
+
+                # Make sure the values for macros are not None so we can
+                # add, and to fit our model
+                res["protein"] = 0
+                res["carbs"] = 0
+                res["fat"] = 0
+                res["fiber"] = 0
+                res["calories"] = 0
+
+                # Do something with the macros, assuming they do not
+                # need to be scaled, i.e. they have proper macro values
+                # according to the recipe
+                for ingredient_macro in ingredient_macros:
+                    res["protein"] += ingredient_macro["protein"]
+                    res["carbs"] += ingredient_macro["carbs"]
+                    res["fat"] += ingredient_macro["fat"]
+                    res["fiber"] += ingredient_macro["fiber"]
+                    res["calories"] += ingredient_macro["calories"]
+
+                # update recipe macros so we don't need to repeat this
+                # multiple times for the same recipe
+                cursor.close()
+                new_cursor = conn.cursor()
+                new_sql = 'updateRecipeMacros'
+                new_cursor.callproc(new_sql, 
+                    (
+                        res["recipe_id"], 
+                        res["protein"],
+                        res["carbs"],
+                        res["fat"],
+                        res["fiber"],
+                        res["calories"]
+                    )
+                )
+                conn.commit()
+                
         return res
     except Exception as e:
         print("MYSQL ERROR:", sql)

--- a/backend/app/indexer/recipes.py
+++ b/backend/app/indexer/recipes.py
@@ -53,3 +53,68 @@ def post_recipe(conn, cursor, recipe):
     except Exception as e:
         print("MYSQL ERROR:", sql_proc)
         logging.error(e)
+
+
+def get_recipe(cursor, recipe_id):
+    sql = 'getRecipe'
+    try:
+        cursor.callproc(sql, (recipe_id, ))
+        raw_result = cursor.fetchall()
+        res = {
+            "recipe_id": recipe_id,
+            "name": "",
+            "user_id": "",
+            "protein": 0,
+            "carbs": 0,
+            "calories": 0,
+            "servings": 0,
+            "vegetarian": False,
+            "vegan": False,
+            "cooking_time": 0,
+            "steps": [],
+            "ingredients": []
+        }
+
+        if len(raw_result):
+            res["name"] = raw_result[0][1]
+            res["user_id"] = raw_result[0][2]
+            res["protein"] = raw_result[0][3]
+            res["carbs"] = raw_result[0][4]
+            res["calories"] = raw_result[0][5]
+            res["servings"] = raw_result[0][6]
+            res["vegetarian"] = bool(raw_result[0][7])
+            res["vegan"] = bool(raw_result[0][8])
+            res["cooking_time"] = raw_result[0][9]
+
+            step_ids = set()
+            ingredient_ids = set()
+
+            for result in raw_result:
+                if result[10] not in step_ids:
+                    res["steps"].append(
+                        {
+                            "step_id": result[10],
+                            "description": result[11],
+                            "time": result[12],
+                        }
+                    )
+                    step_ids.add(result[10])
+
+                if result[13] not in ingredient_ids:
+                    res["ingredients"].append(
+                        {
+                            "ingredient_id": result[13],
+                            "ingredient_name": result[14],
+                            "category": result[15]
+                        }
+                    )
+                    ingredient_ids.add(result[13])
+            
+            res["steps"] = sorted(res["steps"], key=lambda step: step["step_id"])
+            res["ingredients"] = sorted(res["ingredients"], key=lambda ingredient: ingredient["ingredient_id"])
+                    
+        print(res)
+        return res
+    except Exception as e:
+        print("MYSQL ERROR:", sql)
+        logging.error(e)

--- a/backend/app/indexer/tools.py
+++ b/backend/app/indexer/tools.py
@@ -10,7 +10,14 @@ MYSQL_DB = os.getenv("MYSQL_DB", "umami_db")
 
 def connect_mysql():
     try:
-        conn = MySQLdb.connect(host=MYSQL_HOST,user=MYSQL_USER,port=MYSQL_PORT,password=MYSQL_PWD,database=MYSQL_DB, local_infile=True)
+        conn = MySQLdb.connect(
+            host=MYSQL_HOST,
+            user=MYSQL_USER,
+            port=MYSQL_PORT,
+            password=MYSQL_PWD,
+            database=MYSQL_DB,
+            local_infile=True
+        )
         return conn
     except Exception as e:
         print("MYSQL ERROR: connect failed")

--- a/backend/app/indexer/users.py
+++ b/backend/app/indexer/users.py
@@ -46,7 +46,7 @@ def update_user(conn, cursor, user):
             paleo,
             style,
             experience
-             ))
+            ))
         conn.commit()
         return user
     except Exception as e:
@@ -94,7 +94,7 @@ def post_user(conn, cursor, user):
             paleo,
             style,
             experience
-             ))
+            ))
         conn.commit()
         return user
     except Exception as e:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,8 @@ app.add_middleware(
     allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"])
+    allow_headers=["*"]
+)
 
 
 app.include_router(user.router)

--- a/backend/app/route/recipe.py
+++ b/backend/app/route/recipe.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from typing import List, Optional, Union
 from pydantic import BaseModel
 import logging
-from app.indexer.tools import init_conn, connect_mysql
+from app.indexer.tools import init_conn
 from app.indexer.recipes import get_recipe_by_keyword, get_all_recipes, post_recipe, get_recipe_by_id
 from datetime import datetime
 

--- a/backend/app/route/recipe.py
+++ b/backend/app/route/recipe.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 from pydantic import BaseModel
 import logging
 from app.indexer.tools import init_conn, connect_mysql
-from app.indexer.recipes import get_recipe_by_keyword, get_all_recipes, post_recipe, get_recipe
+from app.indexer.recipes import get_recipe_by_keyword, get_all_recipes, post_recipe, get_recipe_by_id
 from datetime import datetime
 
 defaultRecipe = {
@@ -97,11 +97,11 @@ async def create_recipe(recipe: dict = defaultRecipe):
         return "Error with {}".format(e), 400
 
 @router.get("/{recipe_id}", response_model=RecipeDetailsOut)
-async def read_recipe(recipe_id: int):
-    '''get recipe info, steps, and ingredients'''
+async def read_recipe_by_id(recipe_id: int):
+    '''get recipe info, macros, steps, and ingredients'''
     try:
         conn, cursor = init_conn()
-        res = get_recipe(conn, cursor, recipe_id)
+        res = get_recipe_by_id(conn, cursor, recipe_id)
         return {
             "data": res,
             "status_code": 200

--- a/backend/app/route/recipe.py
+++ b/backend/app/route/recipe.py
@@ -37,6 +37,8 @@ class RecipeDetails(BaseModel):
     user_id: str
     protein: int
     carbs: int
+    fat: int
+    fiber: int
     calories: int
     servings: int
     vegetarian: bool
@@ -98,8 +100,8 @@ async def create_recipe(recipe: dict = defaultRecipe):
 async def read_recipe(recipe_id: int):
     '''get recipe info, steps, and ingredients'''
     try:
-        _, cursor = init_conn()
-        res = get_recipe(cursor, recipe_id)
+        conn, cursor = init_conn()
+        res = get_recipe(conn, cursor, recipe_id)
         return {
             "data": res,
             "status_code": 200

--- a/database/sproc/recipeSproc.sql
+++ b/database/sproc/recipeSproc.sql
@@ -1,9 +1,13 @@
 USE `umami_db`;
 
 DROP procedure IF EXISTS `getRecipe`;
-DROP procedure IF EXISTS `addMockRecipes`;
+DROP procedure IF EXISTS `updateRecipeMacros`;
+DROP procedure IF EXISTS `getIngredientInfo`;
+DROP procedure IF EXISTS `addMockRecipe`;
+DROP procedure IF EXISTS `addMockMissingMacroRecipe`;
 DROP procedure IF EXISTS `addMockSteps`;
 DROP procedure IF EXISTS `addMockIngredients`;
+DROP procedure IF EXISTS `addMockIngredientsInfo`;
 
 
 DELIMITER $$
@@ -11,8 +15,10 @@ USE `umami_db`$$
 CREATE PROCEDURE `getRecipe` (IN `_recipe_id` INT)
 BEGIN
 
-SELECT r.recipe_id, r.name, r.user_id, r.protein, r.carbs, r.calories, r.servings, r.vegetarian,
-r.vegan, r.cooking_time, rs.step_id, rs.description, rs.time, i.ingredient_id, i.ingredient_name, i.category
+SELECT r.recipe_id, r.name, r.user_id, r.protein, r.carbs, r.fat, r.fiber,
+r.calories, r.servings, r.vegetarian, r.vegan, r.cooking_time,
+rs.step_id, rs.description, rs.time,
+i.ingredient_id, i.ingredient_name, i.category
 FROM `recipes_table` r
 JOIN `recipe_steps_table` rs ON r.recipe_id = rs.recipe_id
 JOIN `ingredients_table` i ON r.recipe_id = i.recipe_id
@@ -25,11 +31,20 @@ DELIMITER ;
 
 DELIMITER $$
 USE `umami_db`$$
-CREATE PROCEDURE `addMockUser` ()
+CREATE PROCEDURE `updateRecipeMacros` (
+    IN `_recipe_id` INT,
+    IN `_protein` INT,
+    IN `_carbs` INT,
+    IN `_fat` INT,
+    IN `_fiber` INT,
+    IN `_calories` INT
+)
 BEGIN
 
-INSERT INTO `users_table` (`user_id`, `username`, `first_name`, `last_name`, `email`, `location`, `profile_picture`, `recipe_driven`)
-VALUES('abc', 'thenotsohipmillenialchef', 'karen', 'white', 'karenwhite@yahoo.com', 'Shaughnessy', '', 0);
+UPDATE `recipes_table`
+SET `protein` = `_protein`, `carbs` = `_carbs`, `fat` = `_fat`, `fiber` = `_fiber`, `calories` = `_calories`
+WHERE `recipe_id` = `_recipe_id`
+;
 
 END$$
 
@@ -37,11 +52,110 @@ DELIMITER ;
 
 DELIMITER $$
 USE `umami_db`$$
-CREATE PROCEDURE `addMockRecipes` ()
+CREATE PROCEDURE `getIngredientInfo` (IN `_ingredient_id` INT)
 BEGIN
 
-INSERT INTO `recipes_table` (`name`, `user_id`, `protein`, `carbs`, `calories`, `servings`, `vegetarian`, `vegan`, `cooking_time`)
-VALUES('scrambled eggs', 'abc', 10, 1, 300, 1, 1, 0, 5);
+SELECT * FROM `ingredients_info_table`
+WHERE `ingredient_id` = `_ingredient_id`;
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `addMockUser` ()
+BEGIN
+
+INSERT INTO `users_table` (
+    `user_id`,
+    `username`,
+    `first_name`,
+    `last_name`,
+    `email`,
+    `location`,
+    `profile_picture`,
+    `recipe_driven`
+) VALUES(
+    'abc',
+    'thenotsohipmillenialchef',
+    'karen',
+    'white',
+    'karenwhite@yahoo.com',
+    'Shaughnessy',
+    '',
+    0
+);
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `addMockRecipe` ()
+BEGIN
+
+INSERT INTO `recipes_table` (
+    `name`,
+    `user_id`,
+    `protein`,
+    `carbs`,
+    `fat`,
+    `fiber`,
+    `calories`,
+    `servings`,
+    `vegetarian`,
+    `vegan`,
+    `cooking_time`
+) VALUES(
+    'scrambled eggs',
+    'abc',
+    10,
+    1,
+    5,
+    0,
+    300,
+    1,
+    1,
+    0,
+    5
+);
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `addMockMissingMacroRecipe` ()
+BEGIN
+
+INSERT INTO `recipes_table` (
+    `name`,
+    `user_id`,
+    `protein`,
+    `carbs`,
+    `fat`,
+    `fiber`,
+    `calories`,
+    `servings`,
+    `vegetarian`,
+    `vegan`,
+    `cooking_time`
+) VALUES(
+    'scrambled eggs',
+    'abc',
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    1,
+    1,
+    0,
+    5
+);
 
 END$$
 
@@ -81,6 +195,27 @@ VALUES(1, 'pinch of pepper', 'seasoning');
 
 INSERT INTO `ingredients_table` (`recipe_id`, `ingredient_name`, `category`)
 VALUES(1, 'pinch of crushed red pepper', 'seasoning');
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `addMockIngredientsInfo` ()
+BEGIN
+
+INSERT INTO `ingredients_info_table` (`recipe_id`, `ingredient_name`, `category`, `protein`, `carbs`, `fat`, `fiber`, `calories`)
+VALUES(1, '2 eggs', 'alternative protein', 10, 0, 5, 0, 300);
+
+INSERT INTO `ingredients_info_table` (`recipe_id`, `ingredient_name`, `category`, `protein`, `carbs`, `fat`, `fiber`, `calories`)
+VALUES(1, 'pinch of salt', 'seasoning', 0, 0, 0, 0, 0);
+
+INSERT INTO `ingredients_info_table` (`recipe_id`, `ingredient_name`, `category`, `protein`, `carbs`, `fat`, `fiber`, `calories`)
+VALUES(1, 'pinch of pepper', 'seasoning', 0, 0, 0, 0, 0);
+
+INSERT INTO `ingredients_info_table` (`recipe_id`, `ingredient_name`, `category`, `protein`, `carbs`, `fat`, `fiber`, `calories`)
+VALUES(1, 'pinch of crushed red pepper', 'seasoning', 0, 0, 0, 0, 2);
 
 END$$
 

--- a/database/sproc/recipeSproc.sql
+++ b/database/sproc/recipeSproc.sql
@@ -1,0 +1,87 @@
+USE `umami_db`;
+
+DROP procedure IF EXISTS `getRecipe`;
+DROP procedure IF EXISTS `addMockRecipes`;
+DROP procedure IF EXISTS `addMockSteps`;
+DROP procedure IF EXISTS `addMockIngredients`;
+
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `getRecipe` (IN `_recipe_id` INT)
+BEGIN
+
+SELECT r.recipe_id, r.name, r.user_id, r.protein, r.carbs, r.calories, r.servings, r.vegetarian,
+r.vegan, r.cooking_time, rs.step_id, rs.description, rs.time, i.ingredient_id, i.ingredient_name, i.category
+FROM `recipes_table` r
+JOIN `recipe_steps_table` rs ON r.recipe_id = rs.recipe_id
+JOIN `ingredients_table` i ON r.recipe_id = i.recipe_id
+WHERE r.recipe_id = `_recipe_id`
+;
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `addMockUser` ()
+BEGIN
+
+INSERT INTO `users_table` (`user_id`, `username`, `first_name`, `last_name`, `email`, `location`, `profile_picture`, `recipe_driven`)
+VALUES('abc', 'thenotsohipmillenialchef', 'karen', 'white', 'karenwhite@yahoo.com', 'Shaughnessy', '', 0);
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `addMockRecipes` ()
+BEGIN
+
+INSERT INTO `recipes_table` (`name`, `user_id`, `protein`, `carbs`, `calories`, `servings`, `vegetarian`, `vegan`, `cooking_time`)
+VALUES('scrambled eggs', 'abc', 10, 1, 300, 1, 1, 0, 5);
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `addMockSteps` ()
+BEGIN
+
+INSERT INTO `recipe_steps_table` (`recipe_id`, `description`, `time`)
+VALUES(1, 'crack two eggs into a small bowl', NULL);
+
+INSERT INTO `recipe_steps_table` (`recipe_id`, `description`, `time`)
+VALUES(1, 'add salt, pepper, and crushed red pepper', NULL);
+
+INSERT INTO `recipe_steps_table` (`recipe_id`, `description`, `time`)
+VALUES(1, 'cook in small pan on medium heat, stirring occassionally', 5);
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+USE `umami_db`$$
+CREATE PROCEDURE `addMockIngredients` ()
+BEGIN
+
+INSERT INTO `ingredients_table` (`recipe_id`, `ingredient_name`, `category`)
+VALUES(1, '2 eggs', 'alternative protein');
+
+INSERT INTO `ingredients_table` (`recipe_id`, `ingredient_name`, `category`)
+VALUES(1, 'pinch of salt', 'seasoning');
+
+INSERT INTO `ingredients_table` (`recipe_id`, `ingredient_name`, `category`)
+VALUES(1, 'pinch of pepper', 'seasoning');
+
+INSERT INTO `ingredients_table` (`recipe_id`, `ingredient_name`, `category`)
+VALUES(1, 'pinch of crushed red pepper', 'seasoning');
+
+END$$
+
+DELIMITER ;

--- a/database/tables/ingredients_info.sql
+++ b/database/tables/ingredients_info.sql
@@ -18,6 +18,8 @@ CREATE TABLE `ingredients_info_table` (
   `category` VARCHAR(50),
   `protein` INT,
   `carbs` INT,
+  `fat` INT,
+  `fiber` INT,
   `calories` INT,
   PRIMARY KEY (`ingredient_id`),
   CONSTRAINT fk_recipe_ingredient_info FOREIGN KEY (`recipe_id`)

--- a/database/tables/recipes.sql
+++ b/database/tables/recipes.sql
@@ -18,6 +18,8 @@ CREATE TABLE `recipes_table` (
   `user_id` VARCHAR(50) NOT NULL,
   `protein` INT,
   `carbs` INT,
+  `fat` INT,
+  `fiber` INT,
   `calories` INT,
   `servings` INT,
   `vegetarian` BOOLEAN,


### PR DESCRIPTION
## What It Does
- Adds `get_recipe_by_id` endpoint to return recipe details
- Adds `RecipeDetails` models for response type validation
- Adds `fat` and `fiber` macros as columns to `recipes_table` and `ingredients_info_table`

## How to Test
1. Delete the `database/data/` folder

2. Run the `docker-compose up` command to build for the `dev` environment

3. Run the following commands either in MySQL Workbench or by connecting to the database on the command line:
```
USE UMAMI_DB;
CALL addMockUser();
CALL addMockMissingMacroRecipe();
CALL addMockSteps();
CALL addMockIngredients();
CALL addMockIngredientsInfo();
```
**Expected Result:** The commands above should run without any errors. If you encounter an error, you may need to remove the Docker containers and/or images manually. In this case, repeat the previous steps.

4. Go to `localhost:8080/docs/`

5. Expand the GET `/recipe/{recipe_id}` endpoint. Click the "Try it out" button and enter the value `1` into the `recipe_id` field.
**Expected Result:** You should receive a response with the form shown by the example value for a 200 response. If all the previous steps worked, this should also work.

6. Repeat step 5. We should get the same result as we did in step 5. This seems redundant but we are actually testing a different pathway in the code. Since we added a recipe with missing macro values, the first call in step 5 handles the case where these macro values are not present in the `recipes_table` and updates the `recipes_table` with the macro values obtained by querying the `ingredients_info_table`. The second time we call the endpoint only needs to query the `recipes_table` since we now have the macro values.

